### PR TITLE
Fix Transmission of messages by Test Automation Executor

### DIFF
--- a/Sources/BUSMASTER/CAN_IXXAT_VCI/ClientList.cpp
+++ b/Sources/BUSMASTER/CAN_IXXAT_VCI/ClientList.cpp
@@ -96,7 +96,8 @@ void CClientList::DeleteAllEntries()
 HRESULT CClientList::RegisterClient(DWORD& pdwClientID, std::string pacClientName)
 {
     HRESULT hResult = S_FALSE;
-    if (!GetClient(pacClientName))
+    CClientBuffer* pClient = GetClient(pacClientName);
+    if (!pClient)
     {
         // this client is not registered at this time
         if (m_ClientBufferMap.size() <= MAX_CLIENT_ALLOWED)
@@ -104,8 +105,8 @@ HRESULT CClientList::RegisterClient(DWORD& pdwClientID, std::string pacClientNam
             pdwClientID = m_dwUniqueClientID;
 
             // do not forget to delete this object later, we are the creator so we delete it!
-            CClientBuffer* pNewClient = new CClientBuffer(m_dwUniqueClientID, nullptr, nullptr,  pacClientName);
-            m_ClientBufferMap[m_dwUniqueClientID] = pNewClient;
+            CClientBuffer* pClient = new CClientBuffer(m_dwUniqueClientID, nullptr, nullptr, pacClientName);
+            m_ClientBufferMap[m_dwUniqueClientID] = pClient;
             m_dwUniqueClientID++;
             hResult = S_OK;
         }
@@ -120,6 +121,7 @@ HRESULT CClientList::RegisterClient(DWORD& pdwClientID, std::string pacClientNam
     {
         // a client with this name is already registered,
         // write the ID to the variable
+        pdwClientID = pClient->dwClientID;
         hResult = ERR_CLIENT_EXISTS;
     }
     return hResult;

--- a/Sources/BUSMASTER/CAN_IXXAT_VCI/IxxatCanChannel.cpp
+++ b/Sources/BUSMASTER/CAN_IXXAT_VCI/IxxatCanChannel.cpp
@@ -444,7 +444,7 @@ HRESULT CIxxatCanChannel::SendMessage(DWORD dwClientID, const STCAN_MSG& sCanTxM
     HRESULT hResult = HW_INTERFACE_NO_SEL;
     if (m_hCANChannel)
     {
-        CClientBuffer* pClient = m_pClientList->GetClientByID( (int) dwClientID);
+        CClientBuffer* pClient = m_pClientList->GetClientByID(dwClientID);
         if (pClient)
         {
             CANMSG sIxxatCanMsg;


### PR DESCRIPTION
Update the pdwClientID when someone calls RegisterClient() when the node is already registered.
Remove unneeded typecasting in IxxatCanChannel.cpp.

This will fix issue #1098 